### PR TITLE
Modified so that the Time started information in App Stats is represented correctly

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -56,9 +56,9 @@ historian.time.getDate = function(t) {
 historian.time.getTime = function(t) {
   var d = new Date(t);
   return (
-      historian.time.padTime_(d.getHours()) + ':' +
-      historian.time.padTime_(d.getMinutes()) + ':' +
-      historian.time.padTime_(d.getSeconds()));
+      historian.time.padTime_(d.getUTCHours()) + ':' +
+      historian.time.padTime_(d.getUTCMinutes()) + ':' +
+      historian.time.padTime_(d.getUTCSeconds()));
 };
 
 


### PR DESCRIPTION
The value of Time started column in App Stats should be expressed by using getUTCxxx()

e.g. if service.start_time_msec is 1253089, it should be expressed as 00:20:53 but currently expressed as "09:20:53" in my location(KR)

DUMP OF SERVICE batterystats:
Service TempService
        Created for: 20m 53s 89ms uptime
========================================================
== Checkins
========================================================
------ CHECKIN BATTERYSTATS (dumpsys batterystats -c) ------
9,1234,l,apk,672,TempService,1253089,5,5