### PR TITLE
Revert d3 version upgrade

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@ specific language governing permissions and limitations under the License.
 
     <script src="//www.gstatic.com/external_hosted/jquery_form/jquery.form.min.js" charset="utf-8"></script>
 
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/d3/4.9.1/d3.min.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
     {{ if .IsOptimizedJs }}
     <script src="compiled/historian-optimized.js?ver={{.ResVersion}}"></script>
     {{ else }}


### PR DESCRIPTION
d3 v4.x has breaking changes, so it won't work with the current version of battery historian.