### PR TITLE
Error loading history tab content.

### DIFF
--- a/static/historian.css
+++ b/static/historian.css
@@ -174,6 +174,7 @@ rect.level-summary {
 #panel-historian .panel-body {
   padding-left: 4%;
   padding-right: 4%;
+  overflow: auto;
 }
 
 table.values-table td {


### PR DESCRIPTION
The auto overflow was added so that can view the content as it was invading other features on the screen, thus damaging the data visualization.