### PR TITLE
Fix Docker run command example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run the Battery Historian image. Choose a port number and replace `<port>` with
 that number in the commands below:
 
 ```
-docker -- run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
+docker run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
 ```
 
 For Linux and Mac OS X:


### PR DESCRIPTION
When trying to launch the command:

```
docker -- run -p 10000:10000 gcr.io/android-battery-historian/stable:3.0 --port 10000
docker: 'run' is not a docker command.
See 'docker --help'
```
Removing `--` fixes the problem:

```
docker run -p 10000:10000 gcr.io/android-battery-historian/stable:3.0 --port 10000                                                                                                
Unable to find image 'gcr.io/android-battery-historian/stable:3.0' locally
3.0: Pulling from android-battery-historian/stable
c62795f78da9: Pull complete
d4fceeeb758e: Pull complete
5c9125a401ae: Pull complete
0062f774e994: Pull complete
6b33fd031fac: Pull complete
a6bd6e1d0bdb: Pull complete
76cf9d0635af: Pull complete
856d20d533e0: Pull complete
e63a73f6a528: Pull complete
1a75578c9353: Pull complete
24f3649604d9: Pull complete
10f637765748: Pull complete
e06a9fa76cf2: Pull complete
Digest: sha256:265a37707f8cf25f2f85afe3dff31c760d44bb922f64bbc455a4589889d3fe91
Status: Downloaded newer image for gcr.io/android-battery-historian/stable:3.0
2019/03/15 09:36:53 Listening on port:  10000
```