### PR TITLE
Fixed example Docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run the Battery Historian image. Choose a port number and replace `<port>` with
 that number in the commands below:
 
 ```
-docker -- run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
+docker run -p <port>:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
 ```
 
 For Linux and Mac OS X:


### PR DESCRIPTION
The Docker example in the README fails:

```
docker -- run -p 9999:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
docker: 'run' is not a docker command.
See 'docker --help'
```

When `--` is removed it works fine:

```
docker run -p 9999:9999 gcr.io/android-battery-historian/stable:3.0 --port 9999
2019/07/15 16:14:28 Listening on port:  9999
```